### PR TITLE
fix: use sdk instead of old library

### DIFF
--- a/lib/constructs/api.ts
+++ b/lib/constructs/api.ts
@@ -39,9 +39,6 @@ export class ApiConstruct extends Construct {
       "sources.cookie-handler",
       {
         entry: "sources/cookie-handler/index.ts",
-        bundling: {
-          nodeModules: ["aws-cloudfront-sign"],
-        },
         environment: {
           PRIVATE_KEY_SECRET_COMPLETE_ARN: privateKeySecretCompleteArn,
           DOMAIN_NAME: hostedZone.zoneName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "cloudfront-signed-cookie": "bin/cloudfront-signed-cookie.js"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.93",
         "@types/jest": "^26.0.10",
         "@types/node": "10.17.27",
         "aws-cdk": "2.15.0",
@@ -1192,12 +1191,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
-      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -7547,12 +7540,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
-    },
-    "@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.93",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "aws-cdk": "2.15.0",

--- a/sources/cookie-handler/package-lock.json
+++ b/sources/cookie-handler/package-lock.json
@@ -9,12 +9,25 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "aws-cloudfront-sign": "^2.2.0",
         "aws-sdk": "^2.1093.0"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.93",
+        "@types/node": "^17.0.23",
         "aws-lambda": "^1.0.7"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.93",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
+      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -23,14 +36,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/aws-cloudfront-sign": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/aws-cloudfront-sign/-/aws-cloudfront-sign-2.2.0.tgz",
-      "integrity": "sha1-ORD1ptDZD+wH8rTvirB/Pu+1Yl0=",
-      "dependencies": {
-        "lodash": "^3.6.0"
       }
     },
     "node_modules/aws-lambda": {
@@ -166,11 +171,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -246,6 +246,18 @@
     }
   },
   "dependencies": {
+    "@types/aws-lambda": {
+      "version": "8.10.93",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
+      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -253,14 +265,6 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "aws-cloudfront-sign": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/aws-cloudfront-sign/-/aws-cloudfront-sign-2.2.0.tgz",
-      "integrity": "sha1-ORD1ptDZD+wH8rTvirB/Pu+1Yl0=",
-      "requires": {
-        "lodash": "^3.6.0"
       }
     },
     "aws-lambda": {
@@ -359,11 +363,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "punycode": {
       "version": "1.3.2",

--- a/sources/cookie-handler/package.json
+++ b/sources/cookie-handler/package.json
@@ -10,10 +10,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-cloudfront-sign": "^2.2.0",
     "aws-sdk": "^2.1093.0"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.93",
+    "@types/node": "^17.0.23",
     "aws-lambda": "^1.0.7"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* refs: https://github.com/jasonsims/aws-cloudfront-sign/issues/61


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
